### PR TITLE
Install packages after the repositories are added

### DIFF
--- a/states/apt/init.sls
+++ b/states/apt/init.sls
@@ -38,7 +38,7 @@ aptpkgs:
   pkg:
     - installed
     - pkgs: {{ datamap.pkgs }}
-    - order: 1500
+    - order: 2500
 {% endif %}
 
 {% if datamap.purgepkgs|length > 0 %}


### PR DESCRIPTION
Currently this state tries to install packages before repositories are added. With the higher order id this is delayed till after the repo's are added.
