### PR TITLE
Set default to purgepkgs empty

### DIFF
--- a/states/defaults.yaml
+++ b/states/defaults.yaml
@@ -1,6 +1,7 @@
 kernel:
   Linux:
     pkgs: []
+    purgepkgs: []
 os_family:
   Debian:
     sls_include:


### PR DESCRIPTION
When not setting purgepkgs  salt will fail with:
Rendering SLS 'base:repos.apt' failed: Jinja variable 'dict object' has no attribute 'purgepkgs'
